### PR TITLE
Moved common references to platforms, Fixes issue #6

### DIFF
--- a/ManageSleep.nuspec
+++ b/ManageSleep.nuspec
@@ -2,9 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata minClientVersion="2.8.1">
        <id>Xam.Plugins.ManageSleep</id>
-       <version>1.3.0.0</version>
+       <version>1.4.0.0</version>
        <title>ManageSleep Plugin for Xamarin</title>
-       <authors>Molinet Fabien</authors>
+       <authors>Molinet Fabien, Colin Dabritz</authors>
        <owners></owners>
        <iconUrl>http://s10.postimg.org/5xopbbe1h/Manage_Sleep_Icon.png</iconUrl>
        <licenseUrl>https://raw.githubusercontent.com/molinch/Xam.Plugins.ManageSleep/master/LICENSE.md</licenseUrl>
@@ -20,28 +20,36 @@
        </dependencies>
    </metadata>
    <files>
-     <!--Core-->
-     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.dll" target="lib/portable-win+net45+wp8+win8+wpa81/Xam.Plugins.ManageSleep.Common.dll" />
-     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.xml" target="lib/portable-win+net45+wp8+win8+wpa81/Xam.Plugins.ManageSleep.Common.xml" />
     
      <!--Win Phone Silverlight 8-->
      <file src="ManageSleep/Xam.Plugins.ManageSleep.WPSL8/Bin/Release/Xam.Plugins.ManageSleep.WPSL.dll" target="lib/wp8/Xam.Plugins.ManageSleep.WP.dll" />
      <file src="ManageSleep/Xam.Plugins.ManageSleep.WPSL8/Bin/Release/Xam.Plugins.ManageSleep.WPSL.xml" target="lib/wp8/Xam.Plugins.ManageSleep.WP.xml" />
-  	 
-  	 <!--Win Phone 8.1-->
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.dll" target="lib/wp8/Xam.Plugins.ManageSleep.Common.dll" />
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.xml" target="lib/wp8/Xam.Plugins.ManageSleep.Common.xml" />
+
+     <!--Win Phone 8.1-->
      <file src="ManageSleep/Xam.Plugins.ManageSleep.WP/bin/Release/Xam.Plugins.ManageSleep.WP.dll" target="lib/wpa81/Xam.Plugins.ManageSleep.WP.dll" />
      <file src="ManageSleep/Xam.Plugins.ManageSleep.WP/bin/Release/Xam.Plugins.ManageSleep.WP.xml" target="lib/wpa81/Xam.Plugins.ManageSleep.WP.xml" />
-    
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.dll" target="lib/wpa81/Xam.Plugins.ManageSleep.Common.dll" />
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.xml" target="lib/wpa81/Xam.Plugins.ManageSleep.Common.xml" />
+
      <!--Windows 8.1 / Universal-->
      <file src="ManageSleep/Xam.Plugins.ManageSleep.Windows/bin/Release/Xam.Plugins.ManageSleep.Windows.dll" target="lib/Win81/Xam.Plugins.ManageSleep.Windows.dll" />
      <file src="ManageSleep/Xam.Plugins.ManageSleep.Windows/bin/Release/Xam.Plugins.ManageSleep.Windows.xml" target="lib/Win81/Xam.Plugins.ManageSleep.Windows.xml" />
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.dll" target="lib/wpa81/Xam.Plugins.ManageSleep.Common.dll" />
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.xml" target="lib/wpa81/Xam.Plugins.ManageSleep.Common.xml" />
 
      <!--Xamarin.Android-->
      <file src="ManageSleep/Xam.Plugins.ManageSleep.Droid/bin/Release/Xam.Plugins.ManageSleep.Droid.dll" target="lib/MonoAndroid10/Xam.Plugins.ManageSleep.Droid.dll" />
      <file src="ManageSleep/Xam.Plugins.ManageSleep.Droid/bin/Release/Xam.Plugins.ManageSleep.Droid.xml" target="lib/MonoAndroid10/Xam.Plugins.ManageSleep.Droid.xml" />
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.dll" target="lib/MonoAndroid10/Xam.Plugins.ManageSleep.Common.dll" />
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.xml" target="lib/MonoAndroid10/Xam.Plugins.ManageSleep.Common.xml" />
 
-	 <!--Xamarin.iOS Unified-->
+     <!--Xamarin.iOS Unified-->
      <file src="ManageSleep/Xam.Plugins.ManageSleep.TouchUnified/bin/Release/Xam.Plugins.ManageSleep.TouchUnified.dll" target="lib/Xamarin.iOS10/Xam.Plugins.ManageSleep.TouchUnified.dll" />
      <file src="ManageSleep/Xam.Plugins.ManageSleep.TouchUnified/bin/Release/Xam.Plugins.ManageSleep.TouchUnified.xml" target="lib/Xamarin.iOS10/Xam.Plugins.ManageSleep.TouchUnified.xml" />
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.dll" target="lib/Xamarin.iOS10/Xam.Plugins.ManageSleep.Common.dll" />
+     <file src="ManageSleep/Xam.Plugins.ManageSleep.Common/bin/Release/Xam.Plugins.ManageSleep.Common.xml" target="lib/Xamarin.iOS10/Xam.Plugins.ManageSleep.Common.xml" />
+
    </files>
 </package>

--- a/createpackage.bat
+++ b/createpackage.bat
@@ -1,0 +1,1 @@
+nuget pack


### PR DESCRIPTION
* Added batch file to clarify that packaging was done with default nuget pack.
* Incremented version to 1.4.0, shipped 1.4.0 to nuget or (in progress)
* Moved 'common' libraries from portable library to explicit per-platform references

This should mean default nuget package installs get both common and platform references by default and work without modification.

This addresses issue #6 